### PR TITLE
Add allowance for config.sock when connecting

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -49,8 +49,14 @@ export async function normalizeConfig(givenConfig: ConfigGiven): Promise<Config>
   if (config.username && typeof config.username !== 'string') {
     throw new Error('config.username must be a valid string')
   }
-  if (typeof config.host !== 'string' || !config.host) {
+  if ((!config.host) && (!config.sock)) {
+    throw new Error('config.host or config.sock must be used')
+  }
+  if (config.host && typeof config.host !== 'string') {
     throw new Error('config.host must be a valid string')
+  }
+  if (config.sock && Array.isArray(config.sock)) {
+    throw new Error('config.sock must be a valid array')
   }
   if (config.privateKey) {
     const privateKey = config.privateKey


### PR DESCRIPTION
The underlying SSH2 library allows for the usage of raw streams via the 'sock' argument when connecting. This is useful when using another SSH connection via a jump box for multiple hops. 

This change simply relaxes the hard requirement for config.host to exist and adds a restriction that either .host or .sock must exist. If .host exists, the same string check is performed. If .sock exist, it simply checks that the value is an array.