### PR TITLE
Ditch mkdirp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### Upcoming
+
+- Remove `mkdirp` in favor of homegrown solution to ensure compatibility with SSH servers running on Windows
+
 #### 4.2.0
 
 - Fix a typo in README

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "url": "https://github.com/steelbrain/node-ssh/issues"
   },
   "dependencies": {
-    "mkdirp": "^0.5.1",
     "sb-promisify": "^2.0.1",
     "sb-scandir": "^1.0.0",
     "shell-escape": "^0.2.0",

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -30,12 +30,7 @@ export function exists(filePath: string): Promise<boolean> {
 export async function mkdirSftp(path: string, sftp: Object): Promise<void> {
   let stats
   try {
-    stats = await new Promise(function(resolve, reject) {
-      sftp.stat(path, function(error, res) {
-        if (error) reject(error)
-        else resolve(res)
-      })
-    })
+    stats = await promisify(sftp.stat).call(sftp, path)
   } catch (_) { /* No Op */ }
   if (stats) {
     if (stats.isDirectory()) {
@@ -45,7 +40,7 @@ export async function mkdirSftp(path: string, sftp: Object): Promise<void> {
     throw new Error('mkdir() failed, target already exists and is not a directory')
   }
   try {
-    await sftp.mkdir(path)
+    await promisify(sftp.mkdir).call(sftp, path)
   } catch (error) {
     throw transformError(error)
   }

--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,7 @@ class SSH {
 
       const makeSftpDirectory = retry =>
         Helpers.mkdirSftp(path, sftp).catch((error) => {
-          if (retry && error && error.message === 'No such file') {
+          if (retry && error && (error.message === 'No such file' || error.code === 'ENOENT')) {
             return this.mkdir(Path.dirname(path), 'sftp', sftp).then(() => makeSftpDirectory(false))
           }
           throw error


### PR DESCRIPTION
`mkdirp` is a tool mainly for creating local directories, it's buggy when client and server are using different systems.
Fixes #76