### PR TITLE
fix passing options to execCommand

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -111,7 +111,7 @@ class SSH {
     }
     const output = { stdout: [], stderr: [] }
     return new Promise(function(resolve, reject) {
-      connection.exec(command, Helpers.generateCallback(function(stream) {
+      connection.exec(command, options.options || {}, Helpers.generateCallback(function(stream) {
         stream.on('data', function(chunk) {
           output.stdout.push(chunk)
         })
@@ -125,7 +125,7 @@ class SSH {
         stream.on('close', function(code, signal) {
           resolve({ code, signal, stdout: output.stdout.join('').trim(), stderr: output.stderr.join('').trim() })
         })
-      }, reject), options.options || {})
+      }, reject))
     })
   }
   async getFile(localFile: string, remoteFile: string, givenSftp: ?Object = null, givenOpts: ?Object = null): Promise<void> {


### PR DESCRIPTION
`ssh2` requires the `exec` options to be the second argument. If the options are the third argument, they get discarded: https://github.com/mscdex/ssh2/blob/master/lib/client.js#L718.
As a result, currently passing options via `execCommand` doesn't work.
This PR fixes the behavior by swapping the order of the options and callback arguments.