### PR TITLE
Added close event handler

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,16 @@ class SSH {
               this.connection = null
             }
           })
+          connection.on('close', hadError => {
+            if (this.connection === connection) {
+              this.connection = null
+            }
+            if (hadError) {
+              reject()
+            } else {
+              resolve(this)
+            }
+          })
           connection.connect(config)
         }),
     )

--- a/src/index.js
+++ b/src/index.js
@@ -35,15 +35,11 @@ class SSH {
               this.connection = null
             }
           })
-          connection.on('close', hadError => {
+          connection.on('close', () => {
             if (this.connection === connection) {
               this.connection = null
             }
-            if (hadError) {
-              reject()
-            } else {
-              resolve(this)
-            }
+            reject(new Error('No response from server'))
           })
           connection.connect(config)
         }),


### PR DESCRIPTION
In case of multiple concurrent connections to same server ssh2 sometimes will fire `close` event instead of `end` event.
We need to handle it to avoid never resolved/rejected Promises.