### PR TITLE
Housekeeping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 #### 10.0.0
 
 * Unixy all paths before passing onwards
+* Add `isConnected` method
 
 #### 9.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 10.0.0
+
+* Unixy all paths before passing onwards
+
 #### 9.0.0
 
 * Add support for Putty private key files

--- a/README.md
+++ b/README.md
@@ -151,7 +151,10 @@ interface SSHGetPutDirectoryOptions extends SSHPutFilesOptions {
 
 class NodeSSH {
     connection: Client | null;
+
     connect(config: Config): Promise<this>;
+
+    isConnected(): boolean;
 
     requestShell(): Promise<ClientChannel>;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -234,6 +234,10 @@ class NodeSSH {
     return this
   }
 
+  public isConnected(): boolean {
+    return this.connection != null
+  }
+
   async requestShell(): Promise<ClientChannel> {
     const connection = this.getConnection()
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,12 +9,6 @@ import { Client, ConnectConfig, ClientChannel, SFTPWrapper, ExecOptions } from '
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { Prompt, Stats, TransferOptions } from 'ssh2-streams'
 
-const DEFAULT_CONCURRENCY = 5
-const DEFAULT_VALIDATE = (path: string) => !fsPath.basename(path).startsWith('.')
-const DEFAULT_TICK = () => {
-  /* No Op */
-}
-
 type Config = ConnectConfig & {
   password?: string
   privateKey?: string
@@ -62,6 +56,25 @@ interface SSHGetPutDirectoryOptions extends SSHPutFilesOptions {
 }
 
 type SSHMkdirMethod = 'sftp' | 'exec'
+
+const DEFAULT_CONCURRENCY = 5
+const DEFAULT_VALIDATE = (path: string) => !fsPath.basename(path).startsWith('.')
+const DEFAULT_TICK = () => {
+  /* No Op */
+}
+
+class SSHError extends Error {
+  constructor(message: string, public code: string | null = null) {
+    super(message)
+  }
+}
+
+function unixifyPath(path: string) {
+  if (path.includes('\\')) {
+    return path.split('\\').join('/')
+  }
+  return path
+}
 
 async function readFile(filePath: string): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -116,12 +129,6 @@ async function makeDirectoryWithSftp(path: string, sftp: SFTPWrapper) {
       }
       throw err
     }
-  }
-}
-
-class SSHError extends Error {
-  constructor(message: string, public code: string | null = null) {
-    super(message)
   }
 }
 
@@ -388,13 +395,13 @@ class NodeSSH {
     invariant(givenSftp == null || typeof givenSftp === 'object', 'sftp must be a valid object')
 
     if (method === 'exec') {
-      await this.exec('mkdir', ['-p', path])
+      await this.exec('mkdir', ['-p', unixifyPath(path)])
       return
     }
     const sftp = givenSftp || (await this.requestSFTP())
 
     const makeSftpDirectory = async (retry: boolean) =>
-      makeDirectoryWithSftp(path, sftp).catch(async (error: SSHError) => {
+      makeDirectoryWithSftp(unixifyPath(path), sftp).catch(async (error: SSHError) => {
         if (!retry || error == null || (error.message !== 'No such file' && error.code !== 'ENOENT')) {
           throw error
         }
@@ -426,7 +433,7 @@ class NodeSSH {
 
     try {
       await new Promise((resolve, reject) => {
-        sftp.fastGet(remoteFile, localFile, transferOptions || {}, err => {
+        sftp.fastGet(remoteFile, unixifyPath(localFile), transferOptions || {}, err => {
           if (err) {
             reject(err)
           } else {
@@ -463,11 +470,12 @@ class NodeSSH {
 
     const putFile = (retry: boolean) => {
       return new Promise(function(resolve, reject) {
-        sftp.fastPut(localFile, remoteFile, transferOptions || {}, err => {
+        sftp.fastPut(localFile, unixifyPath(remoteFile), transferOptions || {}, err => {
           if (err == null) {
             resolve()
             return
           }
+
           if (err.message === 'No such file' && retry) {
             resolve(this.mkdir(fsPath.dirname(remoteFile), 'sftp', sftp).then(() => putFile(false)))
           } else {
@@ -574,14 +582,7 @@ class NodeSSH {
         directories.forEach(directory => {
           queue
             .add(async () => {
-              await this.mkdir(
-                fsPath
-                  .join(remoteDirectory, directory)
-                  .split(fsPath.sep)
-                  .join('/'),
-                'sftp',
-                sftp,
-              )
+              await this.mkdir(fsPath.join(remoteDirectory, directory), 'sftp', sftp)
             })
             .catch(reject)
         })
@@ -597,10 +598,7 @@ class NodeSSH {
           queue
             .add(async () => {
               const localFile = fsPath.join(localDirectory, file)
-              const remoteFile = fsPath
-                .join(remoteDirectory, file)
-                .split(fsPath.sep)
-                .join('/')
+              const remoteFile = fsPath.join(remoteDirectory, file)
               try {
                 await this.putFile(localFile, remoteFile, sftp, transferOptions)
                 tick(localFile, remoteFile, null)
@@ -685,13 +683,6 @@ class NodeSSH {
     directories.sort((a, b) => a.length - b.length)
 
     let failed = false
-    const directoriesCreated = new Set()
-
-    const createDirectory = async (path: string) => {
-      if (!directoriesCreated.has(path)) {
-        directoriesCreated.add(path)
-      }
-    }
 
     try {
       // Do the directories first.
@@ -701,12 +692,7 @@ class NodeSSH {
         directories.forEach(directory => {
           queue
             .add(async () => {
-              await makeDir(
-                fsPath
-                  .join(localDirectory, directory)
-                  .split('/')
-                  .join(fsPath.sep),
-              )
+              await makeDir(fsPath.join(localDirectory, directory))
             })
             .catch(reject)
         })
@@ -722,11 +708,7 @@ class NodeSSH {
           queue
             .add(async () => {
               const localFile = fsPath.join(localDirectory, file)
-              const remoteFile = fsPath
-                .join(remoteDirectory, file)
-                .split(fsPath.sep)
-                .join('/')
-              await createDirectory(fsPath.dirname(remoteFile))
+              const remoteFile = fsPath.join(remoteDirectory, file)
               try {
                 await this.getFile(localFile, remoteFile, sftp, transferOptions)
                 tick(localFile, remoteFile, null)


### PR DESCRIPTION
- `node-ssh` now unixifies all input paths so you don't have to, this may break existing expectations so is under semver-major
- A new `isConnected` method is introduced for convenience 