### PR TITLE
execCommand: always close stdin

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -351,8 +351,8 @@ export class NodeSSH {
         })
         if (options.stdin) {
           channel.write(options.stdin)
-          channel.end()
         }
+        channel.end()
         let code: number | null = null
         let signal: string | null = null
         channel.on('exit', (code_, signal_) => {


### PR DESCRIPTION
I think this fixes some hangs for me with some remote shells expecting stdin somehow; I'm just not sure if it's always ok to close the channel. Perhaps there should be an option to keep the channel open, or perhaps it shouldn't be closed if `onChannel` is passed and that should be the responsibility of the caller?