### PR TITLE
execCommand returns null only if the code is undefined or null

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@types/ssh2": "^0.5.43",
     "ava": "^3.7.0",
     "eslint-config-steelbrain": "^9.0.1",
+    "eslint-plugin-prettier": "^3.3.1",
     "node-pty": "^0.9.0",
     "prettier": "^2.2.1",
     "ssh2-streams": "^0.4.10",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "ava": "^3.7.0",
     "eslint-config-steelbrain": "^9.0.1",
     "node-pty": "^0.9.0",
+    "prettier": "^2.2.1",
     "ssh2-streams": "^0.4.10",
     "ts-node": "^9.0.0",
     "typescript": "^4.0.3"

--- a/src/index.ts
+++ b/src/index.ts
@@ -252,7 +252,7 @@ export class NodeSSH {
       if (options == null) {
         connection.shell(callback)
       } else {
-        connection.shell(options as any, callback)
+        connection.shell(options as PseudoTtyOptions, callback)
       }
     })
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,7 +113,7 @@ async function makeDirectoryWithSftp(path: string, sftp: SFTPWrapper) {
   }
   try {
     await new Promise((resolve, reject) => {
-      sftp.mkdir(path, err => {
+      sftp.mkdir(path, (err) => {
         if (err) {
           reject(err)
         } else {
@@ -447,7 +447,7 @@ export class NodeSSH {
 
     try {
       await new Promise((resolve, reject) => {
-        sftp.fastGet(unixifyPath(remoteFile), localFile, transferOptions || {}, err => {
+        sftp.fastGet(unixifyPath(remoteFile), localFile, transferOptions || {}, (err) => {
           if (err) {
             reject(err)
           } else {
@@ -473,8 +473,8 @@ export class NodeSSH {
     invariant(givenSftp == null || typeof givenSftp === 'object', 'sftp must be a valid object')
     invariant(transferOptions == null || typeof transferOptions === 'object', 'transferOptions must be a valid object')
     invariant(
-      await new Promise(resolve => {
-        fs.access(localFile, fs.constants.R_OK, err => {
+      await new Promise((resolve) => {
+        fs.access(localFile, fs.constants.R_OK, (err) => {
           resolve(err === null)
         })
       }),
@@ -484,7 +484,7 @@ export class NodeSSH {
 
     const putFile = (retry: boolean) => {
       return new Promise((resolve, reject) => {
-        sftp.fastPut(localFile, unixifyPath(remoteFile), transferOptions || {}, err => {
+        sftp.fastPut(localFile, unixifyPath(remoteFile), transferOptions || {}, (err) => {
           if (err == null) {
             resolve()
             return
@@ -527,7 +527,7 @@ export class NodeSSH {
 
     try {
       await new Promise((resolve, reject) => {
-        files.forEach(file => {
+        files.forEach((file) => {
           queue
             .add(async () => {
               await this.putFile(file.local, file.remote, sftp, transferOptions)
@@ -565,7 +565,7 @@ export class NodeSSH {
     invariant(typeof localDirectory === 'string' && localDirectory, 'localDirectory must be a string')
     invariant(typeof remoteDirectory === 'string' && remoteDirectory, 'remoteDirectory must be a string')
 
-    const localDirectoryStat: fs.Stats = await new Promise(resolve => {
+    const localDirectoryStat: fs.Stats = await new Promise((resolve) => {
       fs.stat(localDirectory, (err, stat) => {
         resolve(stat || null)
       })
@@ -580,8 +580,8 @@ export class NodeSSH {
       recursive,
       validate,
     })
-    const files = scanned.files.map(item => fsPath.relative(localDirectory, item))
-    const directories = scanned.directories.map(item => fsPath.relative(localDirectory, item))
+    const files = scanned.files.map((item) => fsPath.relative(localDirectory, item))
+    const directories = scanned.directories.map((item) => fsPath.relative(localDirectory, item))
 
     // Sort shortest to longest
     directories.sort((a, b) => a.length - b.length)
@@ -593,7 +593,7 @@ export class NodeSSH {
       await new Promise((resolve, reject) => {
         const queue = new PromiseQueue({ concurrency })
 
-        directories.forEach(directory => {
+        directories.forEach((directory) => {
           queue
             .add(async () => {
               await this.mkdir(fsPath.join(remoteDirectory, directory), 'sftp', sftp)
@@ -608,7 +608,7 @@ export class NodeSSH {
       await new Promise((resolve, reject) => {
         const queue = new PromiseQueue({ concurrency })
 
-        files.forEach(file => {
+        files.forEach((file) => {
           queue
             .add(async () => {
               const localFile = fsPath.join(localDirectory, file)
@@ -650,7 +650,7 @@ export class NodeSSH {
     invariant(typeof localDirectory === 'string' && localDirectory, 'localDirectory must be a string')
     invariant(typeof remoteDirectory === 'string' && remoteDirectory, 'remoteDirectory must be a string')
 
-    const localDirectoryStat: fs.Stats = await new Promise(resolve => {
+    const localDirectoryStat: fs.Stats = await new Promise((resolve) => {
       fs.stat(localDirectory, (err, stat) => {
         resolve(stat || null)
       })
@@ -678,7 +678,7 @@ export class NodeSSH {
               if (err) {
                 reject(err)
               } else {
-                resolve(res.map(item => item.filename))
+                resolve(res.map((item) => item.filename))
               }
             })
           })
@@ -697,8 +697,8 @@ export class NodeSSH {
         },
       },
     })
-    const files = scanned.files.map(item => fsPath.relative(remoteDirectory, item))
-    const directories = scanned.directories.map(item => fsPath.relative(remoteDirectory, item))
+    const files = scanned.files.map((item) => fsPath.relative(remoteDirectory, item))
+    const directories = scanned.directories.map((item) => fsPath.relative(remoteDirectory, item))
 
     // Sort shortest to longest
     directories.sort((a, b) => a.length - b.length)
@@ -710,7 +710,7 @@ export class NodeSSH {
       await new Promise((resolve, reject) => {
         const queue = new PromiseQueue({ concurrency })
 
-        directories.forEach(directory => {
+        directories.forEach((directory) => {
           queue
             .add(async () => {
               await makeDir(fsPath.join(localDirectory, directory))
@@ -725,7 +725,7 @@ export class NodeSSH {
       await new Promise((resolve, reject) => {
         const queue = new PromiseQueue({ concurrency })
 
-        files.forEach(file => {
+        files.forEach((file) => {
           queue
             .add(async () => {
               const localFile = fsPath.join(localDirectory, file)

--- a/src/index.ts
+++ b/src/index.ts
@@ -358,8 +358,8 @@ export class NodeSSH {
         let code: number | null = null
         let signal: string | null = null
         channel.on('exit', (code_, signal_) => {
-          code = code_ || null
-          signal = signal_ || null
+          code = code_ ?? null
+          signal = signal_ ?? null
         })
         channel.on('close', () => {
           resolve({

--- a/test/main-test.ts
+++ b/test/main-test.ts
@@ -134,6 +134,12 @@ sshit('exec with correct cwd', async function(t, port, client) {
   const result = await client.exec('pwd', [], { cwd: '/etc' })
   t.is(result, '/etc')
 })
+sshit('exec should return correct code', async function (t, port, client) {
+  await connectWithPassword(port, client)
+  const result = await client.exec('echo', ['$some', 'S\\Thing', '"Yo"'], { stream: 'both' })
+  t.is(result.stdout, '$some S\\Thing "Yo"')
+  t.is(result.code, 0)
+})
 sshit('throws if stream is stdout and stuff is written to stderr', async function(t, port, client) {
   await connectWithPassword(port, client)
   try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2297,6 +2297,11 @@ prettier@1.18.2:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
   integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
 
+prettier@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
+
 pretty-ms@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-7.0.1.tgz#7d903eaab281f7d8e03c66f867e239dc32fb73e8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1034,6 +1034,13 @@ eslint-plugin-prettier@3.1.0:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-prettier@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.3.1.tgz#7079cfa2497078905011e6f82e8dd8453d1371b7"
+  integrity sha512-Rq3jkcFY8RYeQLgk2cCwuc0P7SEFwDravPhsJZOQ5N4YI4DSg50NyqJ/9gdZHzQlHf8MvafSesbNJCcP/FF6pQ==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
 eslint-plugin-react-hooks@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz#6210b6d5a37205f0b92858f895a4e827020a7d04"


### PR DESCRIPTION
- Use Typescript's [Nullish Coalescing](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#nullish-coalescing) operator to make sure we only assign `null` to `code` if `code_` is `undefined` or `null`
- I add to bump prettier to support typescript's new operator
- the build fails because `eslint-plugin-prettier` needs to be bumped in `eslint-plugin-steelbrain` (until then I did it in this PR)
