### PR TITLE
Fix exit code handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -370,13 +370,13 @@ export class NodeSSH {
         let code: number | null = null
         let signal: string | null = null
         channel.on('exit', (code_, signal_) => {
-          code = code_ || null
+          code = code_
           signal = signal_ || null
         })
         channel.on('close', () => {
           resolve({
-            code: code != null ? code : null,
-            signal: signal != null ? signal : null,
+            code: code !== null ? code : null,
+            signal: signal !== null ? signal : null,
             stdout: output.stdout.join('').trim(),
             stderr: output.stderr.join('').trim(),
           })


### PR DESCRIPTION
As reported here: https://github.com/steelbrain/node-ssh/issues/404

When return code was 0, null was returned in promise result. This
should fix this.