### PR TITLE
Fix ESM types

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "module": "lib/esm/index.mjs",
   "exports": {
     ".": {
+      "types": "./lib/typings/index.d.ts",
       "import": "./lib/esm/index.mjs",
       "require": "./lib/cjs/index.js"
     },


### PR DESCRIPTION
Hey there!

It appears that the types when using this library in ESM are broken.

Currently based on Typescript's behaviour, it tries to look for the types in the same directory as the `exports.require` field.
Right now this would be `./lib/cjs/index.d.ts`, clearly this is not correct and results in IDEs such as VS Code to not be able to resolve the types.

For reference: https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing