### PR TITLE
Separate private key and private key path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### Upcoming
+
+- BREAKING: `privateKey` config parameter no longer accepts file system paths. Please use the new `privateKeyPath` parameter instead
+
 #### 12.0.5
 
 - Fixed manifest config for Typescript typings. #431 (Thanks @Sikarii)

--- a/README.md
+++ b/README.md
@@ -15,17 +15,16 @@ const ssh = new NodeSSH()
 ssh.connect({
   host: 'localhost',
   username: 'steel',
-  privateKey: '/home/steel/.ssh/id_rsa'
+  privateKeyPath: '/home/steel/.ssh/id_rsa'
 })
-/*
- Or
- ssh.connect({
-   host: 'localhost',
-   username: 'steel',
-   privateKey: fs.readFileSync('/home/steel/.ssh/id_rsa', 'utf8')
- })
- if you want to use the raw string as private key
- */
+
+// or with inline privateKey
+
+ssh.connect({
+  host: 'localhost',
+  username: 'steel',
+  privateKey: Buffer.from('...')
+})
 .then(function() {
   // Local, Remote
   ssh.putFile('/home/steel/Lab/localPath/fileName', '/home/steel/Lab/remotePath/fileName').then(function() {
@@ -110,6 +109,7 @@ declare type Config = ConnectConfig & {
     port?: number;
     username?: string;
     password?: string;
+    privateKeyPath?: string;
     privateKey?: string;
     passphrase?: string;
     tryKeyboard?: boolean;

--- a/test/main-test.ts
+++ b/test/main-test.ts
@@ -53,7 +53,7 @@ async function connectWithPrivateKey(port, client) {
     host: '127.0.0.1',
     port,
     username: 'steel',
-    privateKey: PRIVATE_KEY_PATH,
+    privateKeyPath: PRIVATE_KEY_PATH,
   })
 }
 async function connectWithInlinePrivateKey(port, client) {

--- a/test/validation-test.ts
+++ b/test/validation-test.ts
@@ -313,10 +313,24 @@ test('throws if privateKey is a file and does not exist', async function (t) {
       await normalizeConfig({
         username: 'asd',
         host: 'localhost',
-        privateKey: keyPath,
+        privateKeyPath: keyPath,
       })
     },
-    `config.privateKey does not exist at given fs path`,
+    `config.privateKeyPath does not exist at given fs path`,
+  )
+})
+test('throws if privateKey is specified and so is privateKeyPath', async function (t) {
+  await throwsAsync(
+    t,
+    async function () {
+      await normalizeConfig({
+        username: 'asd',
+        host: 'localhost',
+        privateKey: 'x',
+        privateKeyPath: 'y',
+      })
+    },
+    `config.privateKeyPath must not be specified when config.privateKey is specified`,
   )
 })
 test('does not throw if privateKey is valid', async function (t) {
@@ -348,7 +362,7 @@ test('does not throw if privateKey is valid', async function (t) {
       await normalizeConfig({
         username: 'asd',
         host: 'localhost',
-        privateKey: PRIVATE_KEY_PATH,
+        privateKeyPath: PRIVATE_KEY_PATH,
       })
     },
     'connect ECONNREFUSED 127.0.0.1:22',


### PR DESCRIPTION
This is going to future proof us against different kinds of private keys. Code doesn't have to be kept up to date. Also in case of an unknown key, it's not going to leak the private key in a syscall to fs functions