### PR TITLE
added trim() to complete command to allow file creation in ssh throug…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -414,7 +414,7 @@ export class NodeSSH {
       invariant(typeof parameters[i] === 'string', `parameters[${i}] must be a valid string`)
     }
 
-    const completeCommand = `${command} ${shellEscape(parameters)}`
+    const completeCommand = `${command} ${shellEscape(parameters)}`.trim();
     const response = await this.execCommand(completeCommand, options)
 
     if (options.stream == null || options.stream === 'stdout') {


### PR DESCRIPTION
Hi I've spotted problem with command execution when You want to use node-ssh to pass for example yaml structure in command with EOT at the end and empty options array it adds not wanted "space" and it breaks file creation. For that reason I've added trim() to fix the issue if no options are available.

Thank You,
Nicram97