### PR TITLE
🆕 Add support for TCP and UNIX socket forwarding

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   "homepage": "https://github.com/steelbrain/node-ssh#readme",
   "devDependencies": {
     "@types/shell-escape": "^0.2.0",
-    "@types/ssh2": "^0.5.47",
     "ava": "^3.15.0",
     "eslint-config-steelbrain": "^11.0.0",
     "node-pty": "^0.10.1",
@@ -52,12 +51,13 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
+    "@types/ssh2": "^1.11.9",
     "is-stream": "^2.0.0",
     "make-dir": "^3.1.0",
     "sb-promise-queue": "^2.1.0",
     "sb-scandir": "^3.1.0",
     "shell-escape": "^0.2.0",
-    "ssh2": "^1.5.0"
+    "ssh2": "^1.11.0"
   },
   "ava": {
     "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,20 +75,20 @@ export type SSHMkdirMethod = 'sftp' | 'exec'
 export type SSHForwardInListener = (
   details: TcpConnectionDetails,
   accept: AcceptConnection<ClientChannel>,
-  reject: RejectConnection
-) => void;
+  reject: RejectConnection,
+) => void
 export interface SSHForwardInDetails {
-  unforward(): Promise<void>;
-  port: number;
+  unforward(): Promise<void>
+  port: number
 }
 
 export type SSHForwardInStreamLocalListener = (
   info: UNIXConnectionDetails,
   accept: AcceptConnection,
-  reject: RejectConnection
-) => void;
+  reject: RejectConnection,
+) => void
 export interface SSHForwardInStreamLocalDetails {
-  unforward(): Promise<void>;
+  unforward(): Promise<void>
 }
 
 const DEFAULT_CONCURRENCY = 1
@@ -810,131 +810,113 @@ export class NodeSSH {
     return !failed
   }
 
-  forwardIn(
-    remoteAddr: string,
-    remotePort: number,
-    onConnection?: SSHForwardInListener
-  ): Promise<SSHForwardInDetails> {
-    const connection = this.getConnection();
+  forwardIn(remoteAddr: string, remotePort: number, onConnection?: SSHForwardInListener): Promise<SSHForwardInDetails> {
+    const connection = this.getConnection()
 
     return new Promise((resolve, reject) => {
       connection.forwardIn(remoteAddr, remotePort, (error, port) => {
         if (error) {
-          reject(error);
-          return;
+          reject(error)
+          return
         }
 
         const handler: SSHForwardInListener = (details, acceptConnection, rejectConnection) => {
           if (details.destIP === remoteAddr && details.destPort === port) {
-            onConnection?.(details, acceptConnection, rejectConnection);
+            onConnection?.(details, acceptConnection, rejectConnection)
           }
-        };
+        }
 
         if (onConnection) {
-          connection.on('tcp connection', handler);
+          connection.on('tcp connection', handler)
         }
 
         const unforward = (): Promise<void> => {
           return new Promise((_resolve, _reject) => {
-            connection.off('tcp connection', handler);
-            connection.unforwardIn(remoteAddr, port, _error => {
+            connection.off('tcp connection', handler)
+            connection.unforwardIn(remoteAddr, port, (_error) => {
               if (_error) {
-                _reject(error);
+                _reject(error)
               }
 
-              _resolve();
-            });
-          });
-        };
+              _resolve()
+            })
+          })
+        }
 
-        resolve({ port, unforward });
-      });
-    });
+        resolve({ port, unforward })
+      })
+    })
   }
 
-  forwardOut(
-    srcIP: string,
-    srcPort: number,
-    dstIP: string,
-    dstPort: number
-  ): Promise<Channel> {
-    const connection = this.getConnection();
+  forwardOut(srcIP: string, srcPort: number, dstIP: string, dstPort: number): Promise<Channel> {
+    const connection = this.getConnection()
 
     return new Promise((resolve, reject) => {
-      connection.forwardOut(
-        srcIP,
-        srcPort,
-        dstIP,
-        dstPort,
-        (error, channel) => {
-          if (error) {
-            reject(error);
-            return;
-          }
-
-          resolve(channel);
+      connection.forwardOut(srcIP, srcPort, dstIP, dstPort, (error, channel) => {
+        if (error) {
+          reject(error)
+          return
         }
-      );
-    });
+
+        resolve(channel)
+      })
+    })
   }
 
   forwardInStreamLocal(
     socketPath: string,
-    onConnection?: SSHForwardInStreamLocalListener
+    onConnection?: SSHForwardInStreamLocalListener,
   ): Promise<SSHForwardInStreamLocalDetails> {
-    const connection = this.getConnection();
+    const connection = this.getConnection()
 
     return new Promise((resolve, reject) => {
-      connection.openssh_forwardInStreamLocal(socketPath, error => {
+      connection.openssh_forwardInStreamLocal(socketPath, (error) => {
         if (error) {
-          reject(error);
-          return;
+          reject(error)
+          return
         }
 
-        const handler: SSHForwardInStreamLocalListener = (
-          details,
-          acceptConnection, rejectConnection
-        ) => {
+        const handler: SSHForwardInStreamLocalListener = (details, acceptConnection, rejectConnection) => {
           if (details.socketPath === socketPath) {
-            onConnection?.(details, acceptConnection, rejectConnection);
+            onConnection?.(details, acceptConnection, rejectConnection)
           }
-        };
+        }
 
         if (onConnection) {
-          connection.on('unix connection', handler);
+          connection.on('unix connection', handler)
         }
 
         const unforward = (): Promise<void> => {
           return new Promise((_resolve, _reject) => {
-            connection.off('unix connection', handler);
-            connection.openssh_unforwardInStreamLocal(socketPath, _error => {
+            connection.off('unix connection', handler)
+            connection.openssh_unforwardInStreamLocal(socketPath, (_error) => {
               if (_error) {
-                _reject(_error);
+                _reject(_error)
               }
 
-              _resolve();
-            });
-          });
-        };
+              _resolve()
+            })
+          })
+        }
 
-        resolve({ unforward });
-      });
-    });
+        resolve({ unforward })
+      })
+    })
   }
 
   forwardOutStreamLocal(socketPath: string): Promise<Channel> {
-    const connection = this.getConnection();
+    const connection = this.getConnection()
 
     return new Promise((resolve, reject) => {
       connection.openssh_forwardOutStreamLocal(socketPath, (error, channel) => {
         if (error) {
-          reject(error);
-          return;
+          reject(error)
+          return
         }
 
-        resolve(channel);
-      });
-    });
+        resolve(channel)
+      })
+    })
   }
 
   dispose(): void {

--- a/src/ssh2.d.ts
+++ b/src/ssh2.d.ts
@@ -1,0 +1,12 @@
+import 'ssh2'
+
+// The types from DefinitelyTyped are inaccurate.
+declare module 'ssh2' {
+  interface SFTPWrapper {
+    end(): void
+  }
+
+  interface ClientChannel {
+    close(): boolean
+  }
+}


### PR DESCRIPTION
I've added support for the TCP/UNIX socket forwarding functions and also:

* Moved `@types/ssh2` to dependencies - since you're reexporting those, I think it's good to include them like that. This has no impact on generated code.
* Added type definitions for `SFTPWrapper`.`end` and `ClientChannel`.`close` since those were missing from type definitions in DefinitelyTyped but are present in `ssh2` itself. I am going to open a pull request for DefinitelyTyped soon.