### PR TITLE
Remove trim on result of exec command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ export interface SSHExecCommandOptions {
   stdin?: string | stream.Readable
   execOptions?: ExecOptions
   encoding?: BufferEncoding
+  noTrim?: boolean
   onChannel?: (clientChannel: ClientChannel) => void
   onStdout?: (chunk: Buffer) => void
   onStderr?: (chunk: Buffer) => void
@@ -417,11 +418,18 @@ export class NodeSSH {
           signal = signal_ ?? null
         })
         channel.on('close', () => {
+          let stdout = output.stdout.join('')
+          let stderr = output.stderr.join('')
+          if (options.noTrim === false) {
+            stdout = stdout.trim()
+            stderr = stderr.trim()
+          }
+
           resolve({
             code: code != null ? code : null,
             signal: signal != null ? signal : null,
-            stdout: output.stdout.join('').trim(),
-            stderr: output.stderr.join('').trim(),
+            stdout: stdout,
+            stderr: stderr,
           })
         })
       })

--- a/src/index.ts
+++ b/src/index.ts
@@ -420,7 +420,7 @@ export class NodeSSH {
         channel.on('close', () => {
           let stdout = output.stdout.join('')
           let stderr = output.stderr.join('')
-          if (options.noTrim === false) {
+          if (options.noTrim !== true) {
             stdout = stdout.trim()
             stderr = stderr.trim()
           }


### PR DESCRIPTION
Hello,
I'm using this library to execute command on remote host,
and I want the result to be exactly same as what executed locally.

I think trimming process is a choice of user of library side, not what the library should perform.
Therefore, this PR removes trim method on stdout and stderr results.